### PR TITLE
Add the path parameter to the upload function's signature

### DIFF
--- a/webapp/app/Contracts/FileUploaderContract.php
+++ b/webapp/app/Contracts/FileUploaderContract.php
@@ -2,7 +2,7 @@
 
 interface FileUploaderContract{
 
-	public function upload($file);
+	public function upload($file, $path = NULL);
 
 }
 

--- a/webapp/app/Services/ImageService.php
+++ b/webapp/app/Services/ImageService.php
@@ -31,7 +31,7 @@ class ImageService{
 			if($this->isValid($file))
 			{
 				// If the File upload successfully...
-				if($this->fileUploader->upload($file))
+				if($this->fileUploader->upload($file, public_path().'/theme'))
 				{ 
 					return $file->getClientOriginalName();
 				}

--- a/webapp/app/Services/LaravelFileUploader.php
+++ b/webapp/app/Services/LaravelFileUploader.php
@@ -5,9 +5,9 @@ use App\Contracts\FileUploaderContract;
 class LaravelFileUploader implements FileUploaderContract{
 
 	// Upload a new file
-	public function upload($file)
+	public function upload($file, $path = NULL)
 	{
-		$path = public_path() . '/uploads';
+		$path == null ? $path = public_path() . '/uploads' :  $path;
 		$filename= $file->getClientOriginalName();
 		$newFile = $file->move($path, $filename);
 		return $newFile;


### PR DESCRIPTION
Adding flexibility so we're not tightly coupled to the "upload" folder only. The developer can specify the destination of any file uploaded. 
